### PR TITLE
Fix unknown value representation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/i18n "1.1.0"
+(defproject clanhr/i18n "1.1.1"
   :description "ClanHR's i18n support"
   :url "https://github.com/clanhr/i18n"
   :dependencies [[org.clojure/clojure "1.8.0-RC2"]

--- a/src/clanhr/i18n/core.cljc
+++ b/src/clanhr/i18n/core.cljc
@@ -15,4 +15,4 @@
   [lang token]
   (or (get-in config [:dictionary (keyword lang) (keyword token)])
       (get-in config [:dictionary (:fallback-locale config) (keyword token)])
-      (str "?" token "-" lang "?")))
+      (str "?" (name token) "?")))

--- a/test/clanhr/i18n/core_test.cljc
+++ b/test/clanhr/i18n/core_test.cljc
@@ -4,7 +4,8 @@
 
 (deftest smoke-test
   (testing "unknown"
-    (is (= "?waza-en?" (i18n/t "en" "waza"))))
+    (is (= "?waza?" (i18n/t "en" "waza")))
+    (is (= "?waza?" (i18n/t "en" :waza))))
   (testing "English language"
     (is (= "Vacations" (i18n/t "en" "absence-vacations")))
     (is (= "Vacations" (i18n/t "en" :absence-vacations)))


### PR DESCRIPTION
Our team is used to translate tokens like `?token?` and something like
`?:token-en?` would bring some confusion.