### PR TITLE
Consider translating nil

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/i18n "1.9.0"
+(defproject clanhr/i18n "1.9.1"
   :description "ClanHR's i18n support"
   :url "https://github.com/clanhr/i18n"
   :dependencies [[org.clojure/clojure "1.8.0-RC2"]

--- a/src/clanhr/i18n/core.cljc
+++ b/src/clanhr/i18n/core.cljc
@@ -15,7 +15,8 @@
   ([lang token]
    (t lang token nil))
   ([lang token default-text]
-   (or (get-in config [:dictionary (keyword lang) (keyword token)])
-       default-text
-       (get-in config [:dictionary (:fallback-locale config) (keyword token)])
-       (str "?" (name token) "?"))))
+   (when token
+     (or (get-in config [:dictionary (keyword lang) (keyword token)])
+         default-text
+         (get-in config [:dictionary (:fallback-locale config) (keyword token)])
+         (str "?" (name token) "?")))))

--- a/test/clanhr/i18n/core_test.cljc
+++ b/test/clanhr/i18n/core_test.cljc
@@ -5,6 +5,8 @@
 (deftest smoke-test
   (testing "default"
     (is (= "Waza" (i18n/t "en" "asdasdasdadasdasds" "Waza"))))
+  (testing "nil"
+    (is (= nil (i18n/t "en" nil))))
   (testing "unknown"
     (is (= "?waza?" (i18n/t "en" "waza")))
     (is (= "?waza?" (i18n/t "en" :waza))))


### PR DESCRIPTION
If we gave nil to translate, an exception would be thrown. This patches 
changes the `t` fn so that, if it gets nil, just returns nil. Seems an 
appropriate scenario. If we don't have nothing to translate, return nothing.

This became necessary on the reports, to translate fields. Sometimes the user
fields are nil. This way we can just pass the field value.